### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/flowbroker-ui.yaml
+++ b/.github/workflows/flowbroker-ui.yaml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Build and Push
-        uses: elgohr/Publish-Docker-Github-Action@2.16
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ${{ steps.get_owner.outputs.owner }}/flowbroker-ui
           username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore